### PR TITLE
Fixed "NoMethodError - undefined method `merge' for nil:NilClass:"

### DIFF
--- a/lib/smeagol/wiki.rb
+++ b/lib/smeagol/wiki.rb
@@ -13,6 +13,7 @@ module Smeagol
     self.default_committer_name  = 'Anonymous'
     self.default_committer_email = 'anon@anon.com'
     self.default_ws_subs = ['_','-']
+    self.default_options = {}
 
     # Public: The Smeagol wiki settings. These can be found in the _settings.yml
     # file at the root of the repository.


### PR DESCRIPTION
I guess smeagol was not working anymore since gollum release 2.0.0 

Here's is a fix.
